### PR TITLE
Fix python 3 support and add soft display to examples 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,111 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # Pi-ST7565
+
 ST7565 Graphics LCD Display Python Library for Raspberry Pi.
 Tested with Adafruit ST7565 module.
 Full tutorial on my website [Rototron](http://www.rototron.info/raspberry-pi-graphics-lcd-display-tutorial/) or click picture below for a YouTube video:
 
 [![ST7565 Tutorial](http://img.youtube.com/vi/Nn5u9xhHCTM/0.jpg)](https://youtu.be/Nn5u9xhHCTM)
+
+### Examples
+
+```bash
+python example_polygons.py
+```
+
+When not running on an actual Raspberry Pi, use:
+
+```bash
+MOCK_RPI=true python example_polygons.py
+```
+
+### Soft display
+
+To ease software development, you can use a software display, which uses pygame:
+
+```python
+if os.environ.get('MOCK_RPI'):
+    from soft_display import mock_gpio, Glcd
+    mock_gpio()
+else:
+    from st7565 import Glcd
+```

--- a/example_bitmaps.py
+++ b/example_bitmaps.py
@@ -1,9 +1,10 @@
 from pygame import time
+import os 
+root = os.path.dirname(os.path.realpath(__file__))
 
 from xglcd_font import XglcdFont
 
-from os import environ
-if environ.get('MOCK_RPI') == 'true':
+if os.environ.get('MOCK_RPI') == 'true':
     from soft_display import mock_gpio, Glcd
     mock_gpio()
 else:
@@ -15,7 +16,7 @@ glcd = Glcd(rgb=[21, 20, 16])
 glcd.init()
 glcd.set_backlight_color(0, 0, 100)
 
-path = "./images/"
+path = root + "/images/"
 # Use List comprehension to load raw bitmaps to list
 dogs = [glcd.load_bitmap(path + "dog{0}.raw".format(i)) for i in range(1,8)]
 

--- a/example_bitmaps.py
+++ b/example_bitmaps.py
@@ -1,12 +1,21 @@
-import st7565
 from pygame import time
+
+from xglcd_font import XglcdFont
+
+from os import environ
+if environ.get('MOCK_RPI') == 'true':
+    from soft_display import mock_gpio, Glcd
+    mock_gpio()
+else:
+    from st7565 import Glcd
+
 clock = time.Clock()
 
-glcd = st7565.Glcd(rgb=[21, 20, 16])
+glcd = Glcd(rgb=[21, 20, 16])
 glcd.init()
 glcd.set_backlight_color(0, 0, 100)
 
-path = "/home/pi/Pi-ST7565/images/"
+path = "./images/"
 # Use List comprehension to load raw bitmaps to list
 dogs = [glcd.load_bitmap(path + "dog{0}.raw".format(i)) for i in range(1,8)]
 

--- a/example_clock.py
+++ b/example_clock.py
@@ -1,17 +1,18 @@
 import math
 import time
 import sys
+import os 
+root = os.path.dirname(os.path.realpath(__file__))
 
 from xglcd_font import XglcdFont
 
-from os import environ
-if environ.get('MOCK_RPI') == 'true':
+if os.environ.get('MOCK_RPI') == 'true':
     from soft_display import mock_gpio, Glcd
     mock_gpio()
 else:
     from st7565 import Glcd
 
-neato = XglcdFont('./fonts/Neato5x7.c', 5, 7)
+neato = XglcdFont(root + '/fonts/Neato5x7.c', 5, 7)
 glcd = Glcd(rgb=[21, 20, 16])
 glcd.init()
 x0, y0 = 63, 31

--- a/example_clock.py
+++ b/example_clock.py
@@ -1,10 +1,18 @@
-import st7565
-import xglcd_font as font
 import math
 import time
+import sys
 
-neato = font.XglcdFont('/home/pi/Pi-ST7565/fonts/Neato5x7.c', 5, 7)
-glcd = st7565.Glcd(rgb=[21, 20, 16])
+from xglcd_font import XglcdFont
+
+from os import environ
+if environ.get('MOCK_RPI') == 'true':
+    from soft_display import mock_gpio, Glcd
+    mock_gpio()
+else:
+    from st7565 import Glcd
+
+neato = XglcdFont('./fonts/Neato5x7.c', 5, 7)
+glcd = Glcd(rgb=[21, 20, 16])
 glcd.init()
 x0, y0 = 63, 31
 
@@ -43,6 +51,6 @@ while 1:
     glcd.draw_line(x0, y0, *get_face_xy(hour * 30 - 90, 20))
     glcd.flip()
     while minute == int(time.strftime("%M")):
-        time.sleep(1)
+        time.sleep(100)
         
     

--- a/example_polygons.py
+++ b/example_polygons.py
@@ -1,15 +1,22 @@
-import st7565
-import xglcd_font as font
 from time import sleep
 
-glcd = st7565.Glcd(rgb=[21, 20, 16])
+from xglcd_font import XglcdFont
+
+from os import environ
+if environ.get('MOCK_RPI') == 'true':
+    from soft_display import mock_gpio, Glcd
+    mock_gpio()
+else:
+    from st7565 import Glcd
+
+glcd = Glcd(rgb=[21, 20, 16])
 glcd.init()
 glcd.set_backlight_color(0, 100, 0)
 x0, y0 = 40, 31
 rout, rmid, rin = 30, 20, 10
 incr = 2
-path = "/home/pi/Pi-ST7565/"
-wendy = font.XglcdFont(path + 'fonts/Wendy7x8.c', 7, 8)
+path = './'
+wendy = XglcdFont(path + 'fonts/Wendy7x8.c', 7, 8)
 ship = glcd.load_bitmap(path + 'images/ship_38x29.raw',
                         width=38, height=29, invert=True)
 
@@ -31,3 +38,6 @@ for angle in range(0, 360, incr):
     sleep(.01)
 
 glcd.cleanup()
+
+while True:
+    sleep(1)

--- a/example_polygons.py
+++ b/example_polygons.py
@@ -1,9 +1,10 @@
 from time import sleep
+import os
+root = os.path.dirname(os.path.realpath(__file__))
 
 from xglcd_font import XglcdFont
 
-from os import environ
-if environ.get('MOCK_RPI') == 'true':
+if os.environ.get('MOCK_RPI') == 'true':
     from soft_display import mock_gpio, Glcd
     mock_gpio()
 else:
@@ -15,9 +16,8 @@ glcd.set_backlight_color(0, 100, 0)
 x0, y0 = 40, 31
 rout, rmid, rin = 30, 20, 10
 incr = 2
-path = './'
-wendy = XglcdFont(path + 'fonts/Wendy7x8.c', 7, 8)
-ship = glcd.load_bitmap(path + 'images/ship_38x29.raw',
+wendy = XglcdFont(root + '/fonts/Wendy7x8.c', 7, 8)
+ship = glcd.load_bitmap(root + '/images/ship_38x29.raw',
                         width=38, height=29, invert=True)
 
 for angle in range(0, 360, incr):

--- a/st7565.py
+++ b/st7565.py
@@ -659,9 +659,8 @@ class Glcd(object):
             up to complete on a full pixel.  Therefore diameter = 2 x r + 1.
         """
         coords = np.empty(shape=[sides + 1, 2], dtype="float64")
-        n = np.arange(sides, dtype="float64")
         theta = math.radians(rotate)
-        for s in n:
+        for s in range(sides):
             t = 2.0 * math.pi * s / sides + theta
             coords[s, 0] = r * math.cos(t) + x0
             coords[s, 1] = r * math.sin(t) + y0
@@ -686,10 +685,9 @@ class Glcd(object):
         if self.is_off_grid(x0 - r, y0 - r, x0 + r, y0 + r):
             return
         coords = np.empty(shape=[sides + 1, 2], dtype="float64")
-        n = np.arange(sides, dtype="float64")
         theta = math.radians(rotate)
         # Determine polygon coordinates
-        for s in n:
+        for s in range(sides):
             t = 2.0 * math.pi * s / sides + theta
             coords[s, 0] = r * math.cos(t) + x0
             coords[s, 1] = r * math.sin(t) + y0

--- a/xglcd_font.py
+++ b/xglcd_font.py
@@ -41,21 +41,22 @@ class XglcdFont(object):
             Numpy Array(Uint8): 2D - rows=letters, cols=letter bytes
         """
         data = []
-        with open(path, 'r') as f:
+        with open(path, 'rb') as f:
             for line in f:
                 # Skip lines that do not start with hex values
                 line = line.strip()
-                if len(line) == 0 or line[0:2] != '0x':
+                if len(line) == 0 or line[0:2] != b'0x':
                     continue
                 # Remove comments 
-                comment = line.find('//')
+                comment = line.find(b'//')
                 if comment != -1:
                     line = line[0:comment].strip()
                 # Remove trailing commas
-                if line.endswith(','):
+                if line.endswith(b','):
                     line = line[0:len(line) - 1]
-                # Convert hex strings to integers and append     
-                data.append([int(x, 16) for x in line.split(',')])
+                # Convert hex strings to integers and append
+                
+                data.append([int(x, 16) for x in line.split(b',')])
        
         return np.array(data).astype('uint8')       
 


### PR DESCRIPTION
I'm mainly using python 3, so I fixed some lines to make it work there (make some strings bytearrays, and a np.arange to range()). I've also added the software display to all the examples, which can be enabled with the `MOCK_RPI` env variable. I have documented it in README.md. 

Also, I added a default gitignore from https://github.com/github/gitignore

Still needs to be verified working with the RPi.